### PR TITLE
Feature Implementation for #4

### DIFF
--- a/modules/charPing/CharPing.js
+++ b/modules/charPing/CharPing.js
@@ -84,6 +84,7 @@ class CharPing {
 		char.call('ping').then(() => {
 			if (!this.timers[char.id]) return;
 			// On successful ping
+			char.call('look', { charid: char.id });
 			let t = setTimeout(() => {
 				if (this.timers[char.id] === t) {
 					this._ping(char);


### PR DESCRIPTION
As desired in #4, the best way to keep the bot's status as `Active` is through a periodic `look` command sent targeted at self.